### PR TITLE
パフォーマンス向上

### DIFF
--- a/src/autoUse.ts
+++ b/src/autoUse.ts
@@ -33,7 +33,7 @@ export class AutoUse {
                 const subList = alreadyDeclaredSubList.length > 0
                     ? (alreadyDeclaredSubList.includes(name)
                         ? alreadyDeclaredSubList
-                        : alreadyDeclaredSubList.concat([name]))
+                        : [...alreadyDeclaredSubList, name])
                     : [name];
                 const useStatement = this.useBuilder(packageName, subList);
                 if (alreadyDeclaredModuleSub !== undefined) {

--- a/src/autoUseRegex.ts
+++ b/src/autoUseRegex.ts
@@ -15,10 +15,10 @@ export class AutoUseRegex {
     static readonly USE_SUB = /use [A-Za-z0-9:]+ qw(\/|\()(\s*\w+\s*)*(\/|\));/g;
 
     // e.g) Hoge::Fuga->bar;
-    static readonly METHOD_MODULE = /([A-Z][a-z0-9]*(::)?)+->/;
+    static readonly METHOD_MODULE = /([A-Z][a-z0-9]*(::)?)+->/g;
 
     // e.g) Hoge::Fuga->bar();
-    static readonly SUB_MODULE = /(([A-Z][a-z0-9]*(::)?)+)([a-z0-9_]+)(\(|;)/;
+    static readonly SUB_MODULE = /(([A-Z][a-z0-9]*(::)?)+)([a-z0-9_]+)(\(|;)/g;
 
     static readonly DELIMITER = /\s|\(/g;
 


### PR DESCRIPTION
- `package, use`文が`subModuleMatch`にマッチすることを防ぐために全文を改行でスプリットして，`use, package`かどうかを見ていた
  - 効率が悪い
  - 先に，`use, package`をreplaceしてから`matchAll` で一回だけ正規表現を取るように変更した