### PR TITLE
重複していた場合に対応

### DIFF
--- a/src/autoUse.ts
+++ b/src/autoUse.ts
@@ -1,6 +1,6 @@
 import { AutoUseRegex } from './autoUseRegex';
-import { UseBuilder } from './useBuilder';
 import { DB } from './db';
+import { UseBuilder } from './useBuilder';
 
 export class AutoUse extends UseBuilder {
     private async insertFullyQualifiedModule(): Promise<boolean> {

--- a/src/autoUse.ts
+++ b/src/autoUse.ts
@@ -1,3 +1,5 @@
+import * as vscode from 'vscode';
+
 import { AutoUseRegex } from './autoUseRegex';
 import { DB } from './db';
 import { UseBuilder } from './useBuilder';
@@ -34,10 +36,19 @@ export class AutoUse extends UseBuilder {
 
         const uniqueTokensInFullText = new Set<string>(tokensInFullText);
         const importObjects = [...uniqueTokensInFullText]
-            .map(ut => DB.findByName(ut))
+            .map(ut => DB.findByName(ut));
+
+        const notDuplicateImportObjects = importObjects
             .filter(objects => objects.length === 1)
             .flat(1);
-        return this.insertUseStatementByImportObjects(importObjects);
+
+        const duplicateImportObjects = importObjects
+            .filter(objects => objects.length > 1)
+            .flat(1);
+
+        duplicateImportObjects.forEach(dio => vscode.window.showWarningMessage(`${dio.name} is duplicated. Please solve individually`));
+
+        return this.insertUseStatementByImportObjects(notDuplicateImportObjects);
     }
 
     public async insertModules(): Promise<void> {

--- a/src/autoUse.ts
+++ b/src/autoUse.ts
@@ -1,5 +1,6 @@
 import { AutoUseRegex } from './autoUseRegex';
 import { UseBuilder } from './useBuilder';
+import { DB } from './db';
 
 export class AutoUse extends UseBuilder {
     private async insertFullyQualifiedModule(): Promise<boolean> {
@@ -32,7 +33,11 @@ export class AutoUse extends UseBuilder {
             );
 
         const uniqueTokensInFullText = new Set<string>(tokensInFullText);
-        return this.insertUseStatementByNames([...uniqueTokensInFullText]);
+        const importObjects = [...uniqueTokensInFullText]
+            .map(ut => DB.findByName(ut))
+            .filter(objects => objects.length === 1)
+            .flat(1);
+        return this.insertUseStatementByImportObjects(importObjects);
     }
 
     public async insertModules(): Promise<void> {

--- a/src/autoUseContext.ts
+++ b/src/autoUseContext.ts
@@ -1,0 +1,6 @@
+import * as vscode from 'vscode';
+
+export interface AutoUseContext {
+    extensionContext: vscode.ExtensionContext;
+    editor: vscode.TextEditor;
+};

--- a/src/core.ts
+++ b/src/core.ts
@@ -4,6 +4,7 @@ import { AutoUse } from './autoUse';
 import { DB } from './db';
 import { Scanner } from './scanner';
 import { Selector } from './selector';
+import { SelectUse } from './selectUse';
 
 export class Core {
     private workspace: vscode.WorkspaceFolder | undefined;
@@ -15,7 +16,7 @@ export class Core {
     public attatchCommands(): void {
         const scanCommand = vscode.commands.registerCommand('extension.scanFiles', () => {
             vscode.window.showInformationMessage('Hello World!');
-            const scanner = new Scanner(vscode.workspace.getConfiguration('autouse'));
+            const scanner = new Scanner(this.context, vscode.workspace.getConfiguration('autouse'));
             scanner.scan(this.workspace);
         });
 
@@ -28,8 +29,8 @@ export class Core {
 
             if (editor === undefined) { return; }
 
-            const selector = new Selector(editor);
-            const autoUse = new AutoUse(selector);
+            const selector = new Selector(this.context, editor);
+            const autoUse = new AutoUse(this.context, selector);
             autoUse.insertModules();
         });
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -5,7 +5,6 @@ import { AutoUseContext } from './autoUseContext';
 import { DB } from './db';
 import { Scanner } from './scanner';
 import { SelectUse } from './selectUse';
-import { Selector } from './selector';
 
 export class Core {
     private workspace: vscode.WorkspaceFolder | undefined;
@@ -20,9 +19,9 @@ export class Core {
         });
 
         const scanCommand = vscode.commands.registerCommand('extension.scanFiles', () => {
-            vscode.window.showInformationMessage('Hello World!');
             const scanner = new Scanner(this.context, vscode.workspace.getConfiguration('autouse'));
             scanner.scan(this.workspace);
+            vscode.window.showInformationMessage('Scan done!!');
         });
 
         const showDBCommand = vscode.commands.registerCommand('extension.showDB', () => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -15,7 +15,10 @@ export class Core {
     }
 
     public attatchCommands(): void {
-        const selectUseAction = vscode.languages.registerCodeActionsProvider('perl', new SelectUse(this.context));
+        const selectUseAction = vscode.languages.registerCodeActionsProvider('perl', new SelectUse(this.context), {
+            providedCodeActionKinds: SelectUse.providedCodeActionKinds
+        });
+
         const scanCommand = vscode.commands.registerCommand('extension.scanFiles', () => {
             vscode.window.showInformationMessage('Hello World!');
             const scanner = new Scanner(this.context, vscode.workspace.getConfiguration('autouse'));
@@ -31,11 +34,11 @@ export class Core {
 
             if (editor === undefined) { return; }
 
-            const selector = new Selector(this.context);
             const autoUse = new AutoUse(this.context);
+
             autoUse.insertModules();
         });
 
-        this.context.extensionContext.subscriptions.push(scanCommand, showDBCommand, autoUseCommand);
+        this.context.extensionContext.subscriptions.push(scanCommand, showDBCommand, autoUseCommand, selectUseAction);
     }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,19 +1,21 @@
 import * as vscode from 'vscode';
 
 import { AutoUse } from './autoUse';
+import { AutoUseContext } from './autoUseContext';
 import { DB } from './db';
 import { Scanner } from './scanner';
-import { Selector } from './selector';
 import { SelectUse } from './selectUse';
+import { Selector } from './selector';
 
 export class Core {
     private workspace: vscode.WorkspaceFolder | undefined;
 
-    constructor(private context: vscode.ExtensionContext) {
+    constructor(private context: AutoUseContext) {
         this.workspace = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0] : undefined;
     }
 
     public attatchCommands(): void {
+        const selectUseAction = vscode.languages.registerCodeActionsProvider('perl', new SelectUse(this.context));
         const scanCommand = vscode.commands.registerCommand('extension.scanFiles', () => {
             vscode.window.showInformationMessage('Hello World!');
             const scanner = new Scanner(this.context, vscode.workspace.getConfiguration('autouse'));
@@ -29,11 +31,11 @@ export class Core {
 
             if (editor === undefined) { return; }
 
-            const selector = new Selector(this.context, editor);
-            const autoUse = new AutoUse(this.context, selector);
+            const selector = new Selector(this.context);
+            const autoUse = new AutoUse(this.context);
             autoUse.insertModules();
         });
 
-        this.context.subscriptions.push(scanCommand, showDBCommand, autoUseCommand);
+        this.context.extensionContext.subscriptions.push(scanCommand, showDBCommand, autoUseCommand);
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,15 +1,25 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
-import { Core } from './core';
 
+import { AutoUseContext } from './autoUseContext';
+import { Core } from './core';
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
-export function activate(context: vscode.ExtensionContext) {
+export function activate(ctx: vscode.ExtensionContext) {
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
 	console.log('Congratulations, your extension "auto-use" is now active!');
+
+	const editor = vscode.window.activeTextEditor;
+
+	if (editor === undefined) { return; }
+
+	const context: AutoUseContext = {
+		extensionContext: ctx,
+		editor: editor
+	};
 
 	const core = new Core(context);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,15 +1,9 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
 import { AutoUseContext } from './autoUseContext';
 import { Core } from './core';
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
-export function activate(ctx: vscode.ExtensionContext) {
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
+export function activate(ctx: vscode.ExtensionContext) {
 	console.log('Congratulations, your extension "auto-use" is now active!');
 
 	const editor = vscode.window.activeTextEditor;
@@ -26,5 +20,4 @@ export function activate(ctx: vscode.ExtensionContext) {
 	core.attatchCommands();
 }
 
-// this method is called when your extension is deactivated
 export function deactivate() { }

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -7,7 +7,7 @@ import { readFile } from 'fs';
 export class Scanner {
     private filesToScan: string;
 
-    constructor(private config: vscode.WorkspaceConfiguration) {
+    constructor(private context: vscode.ExtensionContext, private config: vscode.WorkspaceConfiguration) {
         this.filesToScan = this.config.get<string>('filesToScan', '**/lib/**/*.pm');
     }
 

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { AutoUseContext } from './autoUseContext';
 import { AutoUseRegex } from './autoUseRegex';
 import { DB } from './db';
 import { readFile } from 'fs';
@@ -7,7 +8,7 @@ import { readFile } from 'fs';
 export class Scanner {
     private filesToScan: string;
 
-    constructor(private context: vscode.ExtensionContext, private config: vscode.WorkspaceConfiguration) {
+    constructor(private context: AutoUseContext, private config: vscode.WorkspaceConfiguration) {
         this.filesToScan = this.config.get<string>('filesToScan', '**/lib/**/*.pm');
     }
 

--- a/src/selectUse.ts
+++ b/src/selectUse.ts
@@ -32,7 +32,7 @@ export class SelectUse extends UseBuilder implements vscode.CodeActionProvider {
     private actionHandler(importObjects: ImportObject[]): vscode.Command[] {
         return importObjects.map(io => {
             const command: vscode.Command = {
-                title: `$import ${io.name} from ${io.packageName}`,
+                title: `import ${io.name} from ${io.packageName}`,
                 command: COMMAND_INSERT_SELECT_USE,
                 arguments: [[io]]
             };

--- a/src/selectUse.ts
+++ b/src/selectUse.ts
@@ -2,18 +2,21 @@ import * as vscode from 'vscode';
 
 import { DB, ImportObject } from './db';
 
+import { AutoUseContext } from './autoUseContext';
 import { Selector } from './selector';
 import { UseBuilder } from './useBuilder';
 
 const COMMAND_INSERT_SELECT_USE = 'extension.insertSelectUse';
 
 export class SelectUse extends UseBuilder implements vscode.CodeActionProvider {
-    constructor(context: vscode.ExtensionContext, selector: Selector) {
-        super(context, selector);
+    constructor(context: AutoUseContext) {
+        super(context);
+
         const insertSelectUseCommand = vscode.commands.registerCommand(COMMAND_INSERT_SELECT_USE, (importObjects: ImportObject[]) => {
             this.insertUseStatementByImportObjects(importObjects);
         });
-        context.subscriptions.push(insertSelectUseCommand);
+
+        context.extensionContext.subscriptions.push(insertSelectUseCommand);
     }
 
     public provideCodeActions(document: vscode.TextDocument, selection: vscode.Selection, ctx: vscode.CodeActionContext): vscode.Command[] | undefined {

--- a/src/selectUse.ts
+++ b/src/selectUse.ts
@@ -3,12 +3,15 @@ import * as vscode from 'vscode';
 import { DB, ImportObject } from './db';
 
 import { AutoUseContext } from './autoUseContext';
-import { Selector } from './selector';
 import { UseBuilder } from './useBuilder';
 
 const COMMAND_INSERT_SELECT_USE = 'extension.insertSelectUse';
 
 export class SelectUse extends UseBuilder implements vscode.CodeActionProvider {
+    public static readonly providedCodeActionKinds = [
+        vscode.CodeActionKind.QuickFix
+    ];
+
     constructor(context: AutoUseContext) {
         super(context);
 
@@ -29,9 +32,9 @@ export class SelectUse extends UseBuilder implements vscode.CodeActionProvider {
     private actionHandler(importObjects: ImportObject[]): vscode.Command[] {
         return importObjects.map(io => {
             const command: vscode.Command = {
-                title: `${io.name} from ${io.packageName}`,
+                title: `$import ${io.name} from ${io.packageName}`,
                 command: COMMAND_INSERT_SELECT_USE,
-                arguments: [io]
+                arguments: [[io]]
             };
             return command;
         });

--- a/src/selectUse.ts
+++ b/src/selectUse.ts
@@ -25,7 +25,7 @@ export class SelectUse extends UseBuilder implements vscode.CodeActionProvider {
     public provideCodeActions(document: vscode.TextDocument, selection: vscode.Selection, ctx: vscode.CodeActionContext): vscode.Command[] | undefined {
         const selectText = document.getText(selection);
         const importObjects = DB.findByName(selectText);
-        if (importObjects.length <= 1) { return; }
+        if (!this.canHandle(importObjects)) { return; }
         return this.actionHandler(importObjects);
     }
 
@@ -38,5 +38,21 @@ export class SelectUse extends UseBuilder implements vscode.CodeActionProvider {
             };
             return command;
         });
+    }
+
+    private canHandle(importObjects: ImportObject[]): boolean {
+        if (importObjects.length <= 1) { return false; }
+
+        const declaredModuleSub = this.selector.getDeclaredModuleSub();
+
+        if (declaredModuleSub === undefined) { return true; }
+
+        const subName = importObjects[0].name;
+
+        const alreadyDeclaredSub = declaredModuleSub.filter(dms =>
+            dms.subList.includes(subName)
+        ).length > 0;
+
+        return alreadyDeclaredSub ? false : true;
     }
 }

--- a/src/selectUse.ts
+++ b/src/selectUse.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode';
+
+import { DB, ImportObject } from './db';
+
+import { Selector } from './selector';
+import { UseBuilder } from './useBuilder';
+
+const COMMAND_INSERT_SELECT_USE = 'extension.insertSelectUse';
+
+export class SelectUse extends UseBuilder implements vscode.CodeActionProvider {
+    constructor(context: vscode.ExtensionContext, selector: Selector) {
+        super(context, selector);
+        const insertSelectUseCommand = vscode.commands.registerCommand(COMMAND_INSERT_SELECT_USE, (importObjects: ImportObject[]) => {
+            this.insertUseStatementByImportObjects(importObjects);
+        });
+        context.subscriptions.push(insertSelectUseCommand);
+    }
+
+    public provideCodeActions(document: vscode.TextDocument, selection: vscode.Selection, ctx: vscode.CodeActionContext): vscode.Command[] | undefined {
+        const selectText = document.getText(selection);
+        const importObjects = DB.findByName(selectText);
+        if (importObjects.length <= 1) { return; }
+        return this.actionHandler(importObjects);
+    }
+
+    private actionHandler(importObjects: ImportObject[]): vscode.Command[] {
+        return importObjects.map(io => {
+            const command: vscode.Command = {
+                title: `${io.name} from ${io.packageName}`,
+                command: COMMAND_INSERT_SELECT_USE,
+                arguments: [io]
+            };
+            return command;
+        });
+    }
+}

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 
+import { AutoUseContext } from './autoUseContext';
 import { AutoUseRegex } from './autoUseRegex';
 
 interface ModuleSubObject {
@@ -8,7 +9,7 @@ interface ModuleSubObject {
 }
 
 export class Selector {
-    constructor(private context: vscode.ExtensionContext, private editor: vscode.TextEditor) { }
+    constructor(private context: AutoUseContext) { }
 
     private getRangesByRegex(regex: RegExp): vscode.Range[] {
         const fullText = this.getFullText();
@@ -20,21 +21,21 @@ export class Selector {
         return [...matches].reduce((ranges: vscode.Range[], match) => {
             const startIndex = match.index !== undefined ? match.index : 0;
             const endIndex = match.index !== undefined ? match.index + match[0].length : 0;
-            const startPosition = this.editor.document.positionAt(startIndex);
-            const endPosition = this.editor.document.positionAt(endIndex);
+            const startPosition = this.context.editor.document.positionAt(startIndex);
+            const endPosition = this.context.editor.document.positionAt(endIndex);
             ranges.push(new vscode.Range(startPosition, endPosition));
             return ranges;
         }, []);
     }
 
     public getFullText(): string {
-        return this.editor.document.getText();
+        return this.context.editor.document.getText();
     }
 
     public getSelectText(): string {
-        const document = this.editor.document;
+        const document = this.context.editor.document;
         if (document === undefined) { return ''; }
-        return document.getText(this.editor.selection);
+        return document.getText(this.context.editor.selection);
     }
 
     // insert use statement next line of 'package'
@@ -44,7 +45,7 @@ export class Selector {
         if (ranges === []) { return Promise.reject(new Error('no package found')); }
 
         const endPosition = new vscode.Position(ranges[0].end.line + 1, 0);
-        return this.editor.edit(e => useStatements.forEach(useStatement => e.insert(endPosition, useStatement + "\n")));
+        return this.context.editor.edit(e => useStatements.forEach(useStatement => e.insert(endPosition, useStatement + "\n")));
     }
 
     public getFullyQualifiedModules(): string[] | undefined {
@@ -100,6 +101,6 @@ export class Selector {
 
         if (ranges === []) { return Promise.reject('not match'); }
 
-        return this.editor.edit(e => ranges.forEach(range => e.delete(range)));
+        return this.context.editor.edit(e => ranges.forEach(range => e.delete(range)));
     }
 }

--- a/src/selector.ts
+++ b/src/selector.ts
@@ -8,11 +8,7 @@ interface ModuleSubObject {
 }
 
 export class Selector {
-    private editor: vscode.TextEditor;
-
-    constructor(private _editor: vscode.TextEditor) {
-        this.editor = _editor;
-    }
+    constructor(private context: vscode.ExtensionContext, private editor: vscode.TextEditor) { }
 
     private getRangesByRegex(regex: RegExp): vscode.Range[] {
         const fullText = this.getFullText();

--- a/src/useBuilder.ts
+++ b/src/useBuilder.ts
@@ -1,6 +1,4 @@
-import * as vscode from 'vscode';
-
-import { DB, ImportObject } from './db';
+import { ImportObject } from './db';
 
 import { AutoUseContext } from './autoUseContext';
 import { Selector } from './selector';

--- a/src/useBuilder.ts
+++ b/src/useBuilder.ts
@@ -1,10 +1,16 @@
 import * as vscode from 'vscode';
 
 import { DB, ImportObject } from './db';
+
+import { AutoUseContext } from './autoUseContext';
 import { Selector } from './selector';
 
 export class UseBuilder {
-    constructor(protected context: vscode.ExtensionContext, protected selector: Selector) { }
+    protected selector: Selector;
+
+    constructor(protected context: AutoUseContext) {
+        this.selector = new Selector(context);
+    }
 
     protected buildUseStatement(packageName: string, subList: string[] | undefined): string {
         if (subList === undefined) { return 'use ' + packageName + ';'; }

--- a/src/useBuilder.ts
+++ b/src/useBuilder.ts
@@ -1,0 +1,49 @@
+import { DB } from './db';
+import { Selector } from './selector';
+
+export class UseBuilder {
+    protected selector: Selector;
+
+    constructor(private _selector: Selector) {
+        this.selector = _selector;
+    }
+
+    protected buildUseStatement(packageName: string, subList: string[] | undefined): string {
+        if (subList === undefined) { return 'use ' + packageName + ';'; }
+
+        let subListStr = "";
+        for (let i = 0; i < subList.length; i++) {
+            subListStr += (i !== subList.length - 1 ? subList[i] + ' ' : subList[i]);
+        }
+        return 'use ' + packageName + ' qw(' + subListStr + ');';
+    }
+
+    protected async insertUseStatementByNames(names: string[]): Promise<boolean> {
+        let useStatements: string[] = [];
+        const declaredModuleSub = this.selector.getDeclaredModuleSub();
+
+        for (const name of names) {
+            const importObjects = DB.findByName(name);
+
+            if (importObjects.length > 0) {
+                const packageName = importObjects[0].packageName;
+                const alreadyDeclaredModuleSub = declaredModuleSub?.filter(dus => dus.packageName === packageName);
+                const alreadyDeclaredSubList = alreadyDeclaredModuleSub ? alreadyDeclaredModuleSub[0].subList : [];
+                const subList = alreadyDeclaredSubList.length > 0
+                    ? (alreadyDeclaredSubList.includes(name)
+                        ? alreadyDeclaredSubList
+                        : [...alreadyDeclaredSubList, name])
+                    : [name];
+                const useStatement = this.buildUseStatement(packageName, subList);
+                if (alreadyDeclaredModuleSub !== undefined) {
+                    const regex = `use ${packageName} qw(\\/|\\()(\\s*\\w+\\s*)*(\\/|\\));\n|\r\n|\r`;
+                    await this.selector.deleteByRegex(RegExp(regex));
+                }
+                if (useStatement !== '') {
+                    useStatements.push(useStatement);
+                }
+            }
+        }
+        return this.selector.insertUseStatements(useStatements);
+    }
+}

--- a/src/useBuilder.ts
+++ b/src/useBuilder.ts
@@ -30,7 +30,7 @@ export class UseBuilder {
             const packageName = object.packageName;
             const subName = object.name;
             const alreadyDeclaredModuleSub = declaredModuleSub?.filter(dus => dus.packageName === packageName);
-            const alreadyDeclaredSubList = alreadyDeclaredModuleSub ? alreadyDeclaredModuleSub[0].subList : [];
+            const alreadyDeclaredSubList = alreadyDeclaredModuleSub?.length ? alreadyDeclaredModuleSub[0].subList : [];
             const subList = alreadyDeclaredSubList.length > 0
                 ? (alreadyDeclaredSubList.includes(subName)
                     ? alreadyDeclaredSubList


### PR DESCRIPTION
scanされるファイル

`Hoge/Piyo.pm`
``` 
package Hoge::Piyo;

use Exporter 'import';
our @EXPORT = get_public_functions;

sub create_piyo {
    print('create');
}

sub _args_pos {
    print('private so not exported');
}
```

`Hoge/Bar.pm`

```
package Hoge::Bar;

use Exporter 'import';
our @EXPORT = qw/args/;

sub args {
    print 'exported and be duplicate';
}
```

を用意

`Piyo.pm`

```
package Piyo;

sub new_from_name {
    args_pos my $class => 'Class',
             my $name  => 'Str',
    ;
    print('use args_pos');
}

sub song {
    Hoge::Fuga->song;
    print('use fully qualified name');

}

sub walk {
    args my $class => 'Class',
         my $stride => 'Int',
    ;
    print('args is duplicate. so not used')
}
```
を対象としてauto useすると

<img width="1221" alt="スクリーンショット 2020-03-24 14 27 51" src="https://user-images.githubusercontent.com/31027514/77391269-b29b2980-6ddb-11ea-954b-692ecd25b8ff.png">


になって，重複した`args`以外がuseされて，`args is duplicated. Please solve individually` というwarningが出る

argsを選択すると次のような選択肢が出る
<img width="331" alt="スクリーンショット 2020-03-24 14 24 19" src="https://user-images.githubusercontent.com/31027514/77391091-30126a00-6ddb-11ea-89eb-dfc0877f2762.png">

`Smart::Args::TypeTiny`を選ぶと
<img width="394" alt="スクリーンショット 2020-03-24 14 28 53" src="https://user-images.githubusercontent.com/31027514/77391319-d2325200-6ddb-11ea-877b-6e18e4f8db46.png">

が得られる